### PR TITLE
Use Python3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: python
+python:
+    - "3.5"
+    - "3.6"
+    - "3.7-dev"
 
 os:
   - linux
 
-
-
 install:
-  - pip install -r requirements.txt
+  - pip3 install -r requirements.txt
 
 script:
-  - python setup.py test
+  - python3 setup.py test


### PR DESCRIPTION
Since we are targeting python version 3.5/3.6 travis should run tests on python3. 