### PR TITLE
Install source and output submodules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ setup(
     name='camille',
     packages=[
         'camille',
+        'camille/output',
         'camille/process',
+        'camille/source',
         'camille/util',
     ],
     author='Software Innovation Bergen, Equinor ASA',


### PR DESCRIPTION
The source and output submodules where not listed in `setup.py`.